### PR TITLE
Allows na.rm

### DIFF
--- a/codes/sum.R
+++ b/codes/sum.R
@@ -9,6 +9,6 @@
 ##' @export
 ##' 
 
-sum = function(x){
-    base::sum(x, na.rm = !all(is.na(x)))
+sum = function(x, ...){
+    base::sum(x, na.rm = !all(is.na(x)), ...)
 }


### PR DESCRIPTION
When running this function, if you pass na.rm as an argument, you get an "unused argument (na.rm=T)" error.  Adding the "..." fixes this issue.
